### PR TITLE
Fix #2 missing extension dependencies

### DIFF
--- a/druid.c
+++ b/druid.c
@@ -70,21 +70,27 @@
 
 
 ZEND_DECLARE_MODULE_GLOBALS(druid)
-#if ZEND_MODULE_API_NO >= 20050922
-zend_module_dep druid_deps[] =
+
+static zend_module_dep druid_deps[] =
 {
+    ZEND_MOD_REQUIRED("curl")
     ZEND_MOD_REQUIRED("json")
-    {
-        NULL, NULL, NULL
-    }
-};
+#ifdef ZEND_MOD_END
+    ZEND_MOD_END
+#else
+    {NULL, NULL, NULL}
 #endif
+};
 
 static int le_druid;
 
 const zend_function_entry druid_functions[] =
 {
+#ifdef PHP_FE_END
+    PHP_FE_END
+#else
     {NULL, NULL, NULL}
+#endif
 };
 
 const zend_function_entry druid_methods[] =
@@ -108,9 +114,9 @@ const zend_function_entry druid_methods[] =
 
 zend_module_entry druid_module_entry =
 {
-#if ZEND_MODULE_API_NO >= 20010901
-    STANDARD_MODULE_HEADER,
-#endif
+    STANDARD_MODULE_HEADER_EX,
+    NULL,
+    druid_deps,
     DRUID_NAME,
     druid_functions,
     PHP_MINIT(druid),
@@ -118,9 +124,7 @@ zend_module_entry druid_module_entry =
     PHP_RINIT(druid),
     PHP_RSHUTDOWN(druid),
     PHP_MINFO(druid),
-#if ZEND_MODULE_API_NO >= 20010901
     PHP_DRUID_VERSION,
-#endif
     STANDARD_MODULE_PROPERTIES
 };
 


### PR DESCRIPTION
I also clean some old unneeded conditions on PHP version
* 20050922 = 5.1
* 20010901 = 4.2

PHP_FE_END and ZEND_MOD_END exist since 5.3.7 (so I keep the fallback default value)