### PR TITLE
Fix for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
 
 notifications:
   email: neeke@php.net

--- a/druid.c
+++ b/druid.c
@@ -137,7 +137,7 @@ ZEND_END_ARG_INFO()
 const zend_function_entry druid_methods[] =
 {
     PHP_ME(DRUID_NAME, __construct,             druid_void_arginfo, ZEND_ACC_CTOR|ZEND_ACC_PRIVATE)
-    PHP_ME(DRUID_NAME, __clone,                 NULL, ZEND_ACC_CLONE|ZEND_ACC_PRIVATE)
+    PHP_ME(DRUID_NAME, __clone,                 NULL, ZEND_ACC_PRIVATE)
     PHP_ME(DRUID_NAME, __sleep,                 NULL, ZEND_ACC_PRIVATE)
     PHP_ME(DRUID_NAME, __wakeup,                NULL, ZEND_ACC_PRIVATE)
     PHP_ME(DRUID_NAME, __destruct,              NULL, ZEND_ACC_PUBLIC | ZEND_ACC_DTOR)


### PR DESCRIPTION
ZEND_ACC_CLONE have been removed in 7.2
but was not used in previous version (checked in 5.3, 5.4, 5.5, 5.6, 7.0, 7.1)